### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/build.from.main.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.main.branch.deploy.to.dev.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Determine image tags
         if: env.TAG == ''
@@ -50,7 +50,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.release.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.release.branch.deploy.to.dev.yml
@@ -58,7 +58,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Create tag
       uses: actions/github-script@v5
@@ -55,7 +55,7 @@ jobs:
         oc: 4
 
       # https://github.com/redhat-actions/oc-login#readme
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Tag in OpenShift
       run: |
         set -eux

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1
@@ -48,7 +48,7 @@ jobs:
           oc: 4
 
         # https://github.com/redhat-actions/oc-login#readme
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Deploy
         run: |
           set -eux

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1
@@ -48,7 +48,7 @@ jobs:
           oc: 4
 
         # https://github.com/redhat-actions/oc-login#readme
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Deploy
         run: |
           set -eux

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -17,14 +17,14 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 18
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-5Jun-${{ hashFiles('**/pom.xml') }}
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests
         run: mvn -f pom.xml clean package
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.2.5
+        uses: aquasecurity/trivy-action@0.29.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -45,7 +45,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,9 +26,9 @@
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
-        <springdoc.version>1.6.9</springdoc.version>
-        <log4j.version>2.18.0</log4j.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <springdoc.version>1.6.11</springdoc.version>
+        <log4j.version>2.24.3</log4j.version>
     </properties>
 
     <parent>
@@ -86,9 +86,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>21.3.0.0</version>
         </dependency>
         <!--grad-releaseGRAD2-1852 Upgarding API to Spring Boot 3.0.2-->
         <dependency>
@@ -127,7 +127,7 @@
         <dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
-			<version>3.1.0</version>
+			<version>3.2.2</version>
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>
           <artifactId>hibernate-enhance-maven-plugin</artifactId>
-          <version>6.1.1.Final</version>
+          <version>6.6.4.Final</version>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>
@@ -268,7 +268,7 @@
           <plugin>
             <groupId>org.hibernate.orm.tooling</groupId>
             <artifactId>hibernate-enhance-maven-plugin</artifactId>
-            <version>6.1.1.Final</version>
+            <version>6.6.4.Final</version>
             <executions>
               <execution>
                 <configuration>


### PR DESCRIPTION

Change Details:
- Bump org.apache.logging.log4j:log4j-to-slf4j from 2.18.0 to 2.24.3
- Bump org.modelmapper:modelmapper from 3.1.0 to 3.2.2
- Bump org.mapstruct.version from 1.5.2.Final to 1.6.3
- Bump actions/setup-java from 1 to 4
- Bump actions/checkout from 2 to 4
- Bump aquasecurity/trivy-action from 0.2.5 to 0.29.0
- Bump actions/cache from 1 to 4
- Bump docker/login-action from 2 to 3
- Bump springdoc.version from 1.6.9 to 1.6.11
- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.4.Final 
- Upgrade ojdbc8 to ojdbc11